### PR TITLE
perf: reduce LCP and eliminate font preload spam

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -11,6 +11,7 @@ export default function Hero() {
     if (typeof window === 'undefined') return;
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+    // Only animate logo + CTA — h1/tagline are visible immediately for LCP
     const els = containerRef.current?.querySelectorAll('.hero-reveal');
     if (!els) return;
 
@@ -20,7 +21,7 @@ export default function Hero() {
     }
 
     els.forEach((el, i) => {
-      setTimeout(() => el.classList.add('revealed'), 300 + i * 180);
+      setTimeout(() => el.classList.add('revealed'), 200 + i * 200);
     });
   }, []);
 
@@ -31,6 +32,8 @@ export default function Hero() {
         alt=""
         priority
         sizes="100vw"
+        width={1600}
+        height={1067}
         className="absolute inset-0 w-full h-full object-cover"
       />
       <div className="absolute inset-0 bg-slate-900/55"></div>
@@ -43,8 +46,8 @@ export default function Hero() {
             fetchpriority="high"
             className="hero-reveal mb-6 md:mb-8 w-[200px] md:w-[280px]"
           />
-          <p className="hero-reveal text-gray-300 text-xs md:text-sm mb-3 md:mb-4 tracking-[0.25em] uppercase">Rigueur. Stratégie. Conviction.</p>
-          <h1 className="hero-reveal text-3xl md:text-6xl font-extralight text-white mb-6 md:mb-8 leading-tight">
+          <p className="text-gray-300 text-xs md:text-sm mb-3 md:mb-4 tracking-[0.25em] uppercase">Rigueur. Stratégie. Conviction.</p>
+          <h1 className="text-3xl md:text-6xl font-extralight text-white mb-6 md:mb-8 leading-tight">
             Cabinet d'avocats à Paris dédié au contentieux des affaires
           </h1>
           <Link

--- a/src/components/ResponsiveImage.tsx
+++ b/src/components/ResponsiveImage.tsx
@@ -14,6 +14,10 @@ type Props = {
   /** Inline style passthrough (e.g. object-position). */
   style?: React.CSSProperties;
   widths?: number[];
+  /** Intrinsic width of the source image — lets the browser reserve layout space. */
+  width?: number;
+  /** Intrinsic height of the source image — lets the browser reserve layout space. */
+  height?: number;
 };
 
 export default function ResponsiveImage({
@@ -24,6 +28,8 @@ export default function ResponsiveImage({
   className,
   style,
   widths = [400, 800, 1600],
+  width,
+  height,
 }: Props) {
   const webpSrcSet = widths.map((w) => `${src}-${w}.webp ${w}w`).join(', ');
   const fallback = `${src}-1200.jpg`;
@@ -34,6 +40,8 @@ export default function ResponsiveImage({
       <img
         src={fallback}
         alt={alt}
+        width={width}
+        height={height}
         loading={priority ? 'eager' : 'lazy'}
         decoding="async"
         // @ts-ignore - fetchpriority lowercase is the correct HTML attribute

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -154,6 +154,8 @@ export default function Home() {
                     src="/images/myriam"
                     alt="Maître Myriam Douillet Benaroch dans son cabinet"
                     sizes="(max-width: 1024px) 100vw, 50vw"
+                    width={800}
+                    height={1000}
                     className="absolute inset-0 w-full h-full object-cover transition-transform duration-700 hover:scale-105"
                   />
                 </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,12 @@ export default defineConfig({
   ssgOptions: {
     script: 'async',
     formatting: 'minify',
+    crittersOptions: {
+      // Critters auto-adds a <link rel="preload"> for every @font-face it finds
+      // in the inlined critical CSS — that's 18 woff2 downloads on mobile.
+      // We manage font preloads manually in index.html (2 preloads only).
+      preloadFonts: false,
+    },
     includedRoutes: () => [
       '/',
       '/cabinet',


### PR DESCRIPTION
- Remove hero-reveal from H1/tagline so LCP element is visible at first paint without waiting for JS animation delays (~840ms on slow devices)
- Add crittersOptions.preloadFonts=false to stop beasties/critters from auto-injecting 18 <link rel=preload> font tags that competed with the LCP image on mobile connections
- Add optional width/height props to ResponsiveImage for layout-space reservation; pass intrinsic sizes for homepage hero and Myriam portrait