### PR TITLE
fix(mobile): restore Myriam image visibility on smartphone

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -67,13 +67,15 @@
   }
 }
 
-html,
+html {
+  /* `clip` cuts off translateX overflow without creating a scroll container —
+     unlike `hidden`, it doesn't break IntersectionObserver on mobile Safari,
+     which was causing ScrollReveal-wrapped images (e.g. Myriam) to stay
+     invisible because the `revealed` class was never added. */
+  overflow-x: clip;
+}
+
 body {
-  /* Prevent off-screen ScrollReveal translations (translateX(±48px)) from
-     widening the layout viewport on mobile — that was pushing the fixed
-     header past the visible edge and hiding the burger menu. Applied to both
-     html and body because fixed-positioned descendants use the initial
-     containing block (html) for their bounds. */
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## What changed

`overflow-x: hidden` on the `<html>` element was replaced with `overflow-x: clip` in `src/index.css`.

## Why

On mobile (Safari iOS, Chrome Android), `overflow-x: hidden` on `<html>` creates an alternative scroll container. This breaks `IntersectionObserver` — it no longer fires correctly relative to the visual viewport. The `ScrollReveal` component relies on IO to add the `revealed` class; without it, the wrapped element stays at `opacity: 0`.

Concretely: the Myriam photo on the homepage is wrapped in `<ScrollReveal animation="slide-in-right">`. On smartphones the image was permanently invisible.

## How the fix works

`overflow-x: clip` clips overflowing content (same visual result — no horizontal scrollbar) but does **not** create a scroll container. IO continues to observe relative to the real viewport, so `revealed` is added as expected.

This also preserves the original intent of the rule: preventing the `translateX(48px)` initial state of `slide-in-right` from widening the layout viewport and pushing the fixed burger menu off-screen.

## Browser support

`overflow-x: clip` — Chrome 90+, Firefox 81+, Safari 15.4+ (iOS 15.4+, released 2022). Covers all modern mobile browsers in use today.

## Reviewer notes

No JS changes. No layout changes. Only the overflow behaviour on `<html>` is affected.