### PR TITLE
perf(mobile): LCP fetchpriority + finer vendor chunks

### DIFF
--- a/src/components/SeoHead.tsx
+++ b/src/components/SeoHead.tsx
@@ -61,6 +61,8 @@ export default function SeoHead({
           // @ts-ignore
           imagesizes="100vw"
           type="image/webp"
+          // @ts-ignore - fetchpriority lowercase is the correct HTML attribute
+          fetchpriority="high"
         />
       )}
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,9 +76,11 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks(id) {
-          if (id.includes('node_modules')) {
-            return 'vendor';
-          }
+          if (!id.includes('node_modules')) return;
+          if (id.includes('lucide-react')) return 'icons';
+          if (id.includes('react-router') || id.includes('@remix-run')) return 'router';
+          if (id.includes('/react-dom/') || id.includes('/react/') || id.includes('scheduler')) return 'react';
+          return 'vendor';
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add `fetchpriority=\"high\"` on the LCP image preload in `SeoHead` so mobile schedulers prioritize it explicitly.
- Split the monolithic `vendor` chunk into `react` / `router` / `icons` / `vendor` for better caching and parallel download on slow mobile networks.

Both changes target the mobile PageSpeed gap (CPU ×4 + Slow 4G throttling). Modest individual gains; safe to ship before tackling bigger structural wins (page lazy-load, AVIF) which would need new image files and carry more risk.

## Safety
Intentionally **not** touched: `Home.tsx`, `ResponsiveImage.tsx`, `optimize-images.mjs`, `index.css`. No new image variants → zero risk of the immutable-404 cache bug that affected the Myriam portrait previously.

## Test plan
- [x] `npm run build` passes; SSG renders all 14 pages
- [x] `dist/index.html` still references `myriam-v2-*` correctly
- [x] LCP preload link emits `fetchpriority=\"high\"`
- [x] Chunks split as expected (react 45 KB gz, router 22 KB gz, app 22 KB gz, vendor 8 KB gz, icons 1.6 KB gz)
- [ ] Re-run PageSpeed mobile after deploy and compare LCP / TBT

🤖 Generated with [Claude Code](https://claude.com/claude-code)